### PR TITLE
Update goto anything-related shortcuts and descriptions for Sublime Text

### DIFF
--- a/shortcuts.js
+++ b/shortcuts.js
@@ -93,12 +93,13 @@ if('only there were a way to toggle around the parens'){
 }
 
 // command + d : select word(s)
-// command + k while selecting words : don't select word 
+// command + k while selecting words : don't select word
 // command + ctrl + g : select all of words
 // option + mouseDrag : column select
 // command + mouseClick : custom multiple cursor
 
-// command + p : open file
+// command + p : goto anything (use with :line_number, @symbol, #term)
+// command + r : search all function names in current file
 // command + shift + p : set syntax (and many many other things)
 // command + f : find
 // command + shift + f : massive find


### PR DESCRIPTION
The current description of Command + P for Sublime Text only indicates that it can be used to open files. However, it is much more powerful than that. You can use it to navigate to a specific line in a different file, or even see all methods available in whatever file is present in your file structure. This link provides a good  overview of "Goto Anything" along with associated operators:

http://sublime-text-unofficial-documentation.readthedocs.org/en/latest/file_management/file_management.html